### PR TITLE
Update non_conformity_measures.R

### DIFF
--- a/R/non_conformity_measures.R
+++ b/R/non_conformity_measures.R
@@ -20,7 +20,7 @@ Non_conformity_LNR <- function(xi, training_set, mu_r = 1, k=NULL,...) {
   numerator   <- dnorm(xi, mean = mu_r, sd = sigma_f1)
   denominator <- dnorm(xi, mean = mu0_hat, sd = sqrt(1))
   
-  return(numerator / denominator)
+  return(numerator / denominator) #El cociente debe hacerse entre verosimilitudes. Ver la expresión 5 del paper principal
 }
 
 #MAD


### PR DESCRIPTION
Revisa las expresiones 4, 5 y 6 del paper principal, pues esta medida de no conformidad se caracteriza por comparar dos verosimilitudes. 
En esta función no tendrías que armar el producto para calcular la verosimilitud antes y después del punto de cambio. No debería ser algo como: 
```{r}
densities <- dnorm(z, mean = mu0, sd = sigma)
Ln <- prod(densities)            
log_Ln <- sum(log(densities)) 
```